### PR TITLE
Add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ $ git clone git@github.com:OpenCTI-Platform/docs.git
 
 Install dependencies
 ```
-pip install mkdocs mkdocs-material mkdocs-git-authors-plugin mike mkdocs-git-committers-plugin-2 mkdocs-git-revision-date-localized-plugin mkdocs-glightbox 
-lxml
+pip install mkdocs mkdocs-material mkdocs-git-authors-plugin mike mkdocs-git-committers-plugin-2 mkdocs-git-revision-date-localized-plugin mkdocs-glightbox lxml
 ```
 
 Launch the local environment:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ git clone git@github.com:OpenCTI-Platform/docs.git
 
 Install dependencies
 ```
-pip install mkdocs mkdocs-material mkdocs-git-authors-plugin mike mkdocs-git-committers-plugin-2 mkdocs-git-revision-date-localized-plugin mkdocs-glightbox
+pip install mkdocs mkdocs-material mkdocs-git-authors-plugin mike mkdocs-git-committers-plugin-2 mkdocs-git-revision-date-localized-plugin mkdocs-glightbox 
+lxml
 ```
 
 Launch the local environment:

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -168,7 +168,7 @@ $ sudo docker stack deploy --compose-file docker-compose.yml opencti
 You have to install all the needed dependencies for the main application and the workers. The example below is for Debian-based systems:
 
 ```bash
-$ sudo apt-get install nodejs npm python3 python3-pip 
+$ sudo apt-get install build-essential nodejs npm python3 python3-pip python3-dev
 ```
 
 #### Download the application files
@@ -177,8 +177,8 @@ First, you have to [download and extract the latest release file](https://github
 
 **For Linux:**
 
-- If your OS support the libc (Ubuntu, Debian, ...) you have to install the `opencti-release_{RELEASE_VERSION}.tar.gz` version.
-- If your OS uses musl (Alpine, ...) you have to install the `opencti-release-{RELEASE_VERSION}_musl.tar.gz` version
+- If your OS supports libc (Ubuntu, Debian, ...) you have to install the `opencti-release_{RELEASE_VERSION}.tar.gz` version.
+- If your OS uses musl (Alpine, ...) you have to install the `opencti-release-{RELEASE_VERSION}_musl.tar.gz` version.
 
 **For Windows:**
 


### PR DESCRIPTION
We found these missing dependencies as we were trying to set up OpenCTI using Docker.