### PR TITLE
[docs] Deployment overview correction connectors number (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 .cache/
+.idea

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -22,7 +22,8 @@ The workers are standalone Python processes consuming messages from the RabbitMQ
 
 ### Connectors
 
-The connectors are third-party pieces of software (Python processes) that can play four different roles on the platform:
+The connectors are third-party pieces of software (Python processes) that can play five different 
+roles on the platform:
 
 | Type                 | Description                                                                                         | Examples                                                |
 | :------------------- | :-------------------------------------------------------------------------------------------------- | :------------------------------------------------------ |


### PR DESCRIPTION
While reading documentation deployment overview, expected 5 connectors but 4 was written

### Related issues
* https://github.com/OpenCTI-Platform/docs/issues/19