### PR TITLE
Update connectors.md for latest repo structure

### DIFF
--- a/docs/development/connectors.md
+++ b/docs/development/connectors.md
@@ -51,20 +51,18 @@ $ cd connectors
 $ git remote add upstream https://github.com/OpenCTI-Platform/connectors.git
 # Create a branch for your feature/fix
 $ git checkout -b [branch-name]
-$ cp -r template $connector_type/$myconnector
+# Copy the appropriate template directory for the connector type
+$ cp -r templates/$connector_type $connector_type/$myconnector
 $ cd $connector_type/$myconnector
-$ tree .
-.
-├── docker-compose.yml
-├── Dockerfile
-├── entrypoint.sh
-├── README.md
-└── src
-    ├── config.yml.sample
-    ├── main.py
-    └── requirements.txt
+$ ls -R
+Dockerfile              docker-compose.yml      requirements.txt
+README.md               entrypoint.sh           src
 
-1 directory, 7 files
+./src:
+lib     main.py
+
+./src/lib:
+$connector_type.py
 ```
 
 ### Changing the template


### PR DESCRIPTION
## Summary

Updates the tutorial steps for connector creation for the latest directory structure on `main`.  Previously `cp -r template $connector_type/$myconnector` would fail because `template` does not exist.

Also updates the success-check command to `ls` as `tree` isn't always installed on systems, and the outputted files match the new directory structure.

