### PR TITLE
[opensearch] Clarification on OpenSearch Integration Permissions in OpenCTI - #PT-2 

### DIFF
--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -71,7 +71,7 @@ $ cd docker
     thread_pool.search.queue_size=5000
     ```
 
-    - Check the [OpenCTI Integration User Permissions in OpenSearch/ElasticSearch](/deployment/rollover/?h=rollo#opencti-integration-user-permissions-in-opensearchelasticsearch) for detailed information about the necessary user permissions for the OpenSearch/ElasticSearch integration.
+    - Check the [OpenCTI Integration User Permissions in OpenSearch/ElasticSearch](rollover.md#opencti-integration-user-permissions-in-opensearchelasticsearch) for detailed information about the necessary user permissions for the OpenSearch/ElasticSearch integration.
 
 Before running the `docker-compose` command, the `docker-compose.yml` file should be configured. By default, the `docker-compose.yml` file is using environment variables available in the file `.env.sample`.
 

--- a/docs/deployment/rollover.md
+++ b/docs/deployment/rollover.md
@@ -14,7 +14,7 @@ ElasticSearch and OpenSearch both support rollover on indices. OpenCTI has been 
 ## OpenCTI Integration User Permissions in OpenSearch/ElasticSearch
 
 - Index Permissions
-    - **Patterns:** `opencti*` _(Dependent on the parameter [elasticsearch:index_prefix](deployment/configuration/?h=configuration#elasticsearch) value)_
+    - **Patterns:** `opencti*` _(Dependent on the parameter [elasticsearch:index_prefix](configuration.md#elasticsearch) value)_
     - **Permissions:** `indices_all`
 
 - Cluster Permissions


### PR DESCRIPTION
Fix broken link reference from the [Installation » Configure the environment](https://docs.opencti.io/latest/deployment/installation/#configure-the-environment) page to [Deployment » Rollover](https://docs.opencti.io/latest/deployment/rollover/?h=rollover)

---

- Issue Link: https://github.com/OpenCTI-Platform/docs/issues/135
- Previous PR Link:https://github.com/OpenCTI-Platform/docs/pull/138
