### PR TITLE
[docs] Updated installation.md (#192)

### DIFF
--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -100,6 +100,7 @@ CONNECTOR_EXPORT_FILE_CSV_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_IMPORT_FILE_STIX_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_EXPORT_FILE_TXT_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_IMPORT_DOCUMENT_ID=$(cat /proc/sys/kernel/random/uuid)
+CONNECTOR_ANALYSIS_ID=$(cat /proc/sys/kernel/random/uuid)
 SMTP_HOSTNAME=localhost
 EOF
 ) > .env


### PR DESCRIPTION
added environment variable for analysis connector

CONNECTOR_ANALYSIS_ID is added in this [commit](https://github.com/OpenCTI-Platform/docker/commit/90e4e943d9d3588dc064d6df87a5984f58fdb594)
![image](https://github.com/user-attachments/assets/2cfba5fa-9eeb-47b6-8836-e93c9a6bd7d5)

but it wasn't added in docs
![image](https://github.com/user-attachments/assets/375fa53e-8a90-406e-b0e6-4a3e9a22bd29)

which after following the installation document, results in this warning
![image](https://github.com/user-attachments/assets/86853cfa-ebd0-4032-927c-89cb5fc7a258)


