### PR TITLE
[docs] fix helm-opencti charts reference

### DIFF
--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -304,9 +304,9 @@ python3 worker.py &
 
     ---
 
-    OpenCTI Helm Charts for Kubernetes with a global configuration file. More information how to deploy here on [basic installation](https://github.com/devops-ia/helm-opencti/blob/main/opencti/docs/configuration.md) and [examples](https://github.com/devops-ia/helm-opencti/blob/main/opencti/docs/examples.md).
+    OpenCTI Helm Charts for Kubernetes with a global configuration file. More information how to deploy here on [basic installation](https://github.com/devops-ia/helm-opencti/blob/main/charts/opencti/docs/configuration.md) and [examples](https://github.com/devops-ia/helm-opencti/blob/main/charts/opencti/docs/examples.md).
 
-    [:material-github:{ .middle } GitHub Repository](https://github.com/devops-ia/helm-opencti/tree/main/opencti)
+    [:material-github:{ .middle } GitHub Repository](https://github.com/devops-ia/helm-opencti/tree/main/charts/opencti)
 </div>
 
 ### Deploy behind a reverse proxy


### PR DESCRIPTION
We're standarize all repositories from our organization, we would use the same hierarchy of directories for helm-charts. So, we added "charts" subdirectory on repositories, this change force to change the URL which use in your docs because if don't change the URL the users only will recive 404 error:

<img width="465" alt="traffic" src="https://github.com/user-attachments/assets/b28331b3-0bba-48fd-ab6d-815a6cb5ce0c">

Sorry for bother with this change!