### PR TITLE
Add missing required environment variables to the example .env file

### DIFF
--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -89,6 +89,7 @@ OPENCTI_ADMIN_EMAIL=admin@opencti.io
 OPENCTI_ADMIN_PASSWORD=ChangeMePlease
 OPENCTI_ADMIN_TOKEN=$(cat /proc/sys/kernel/random/uuid)
 OPENCTI_BASE_URL=http://localhost:8080
+OPENCTI_HEALTHCHECK_ACCESS_KEY=$(cat /proc/sys/kernel/random/uuid)
 MINIO_ROOT_USER=$(cat /proc/sys/kernel/random/uuid)
 MINIO_ROOT_PASSWORD=$(cat /proc/sys/kernel/random/uuid)
 RABBITMQ_DEFAULT_USER=guest
@@ -100,6 +101,7 @@ CONNECTOR_EXPORT_FILE_CSV_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_IMPORT_FILE_STIX_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_EXPORT_FILE_TXT_ID=$(cat /proc/sys/kernel/random/uuid)
 CONNECTOR_IMPORT_DOCUMENT_ID=$(cat /proc/sys/kernel/random/uuid)
+CONNECTOR_ANALYSIS_ID=$(cat /proc/sys/kernel/random/uuid)
 SMTP_HOSTNAME=localhost
 EOF
 ) > .env


### PR DESCRIPTION
These variables are used by the example `docker-compose.yaml` file but were not included in the example `.env` file in the documentation.

- `OPENCTI_HEALTHCHECK_ACCESS_KEY`
- `CONNECTOR_ANALYSIS_ID`