### PR TITLE
Fix not valid variable

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -140,7 +140,7 @@ Here are the configuration keys, for both containers (environment variables) and
 | Parameter                       | Environment variable             | Default value | Description                                                                                                  |
 |:--------------------------------|:---------------------------------|:--------------|:-------------------------------------------------------------------------------------------------------------|
 | xtm:openbas_url                 | XTM__OPENBAS_URL                 |               | OpenBAS URL                                                                                                  |
-| xtm:openbas_api_url             | XTM__OPENBAS_API_URL             |               | If sets, overrides the API base URL used for the OpenBAS integration                                         |
+| xtm:openbas_api_override_url    | XTM__OPENBAS_API_OVERRIDE_URL    |               | If sets, overrides the API base URL used for the OpenBAS integration                                         |
 | xtm:openbas_token               | XTM__OPENBAS_TOKEN               |               | OpenBAS token                                                                                                |
 | xtm:openbas_reject_unauthorized | XTM__OPENBAS_REJECT_UNAUTHORIZED | false         | Enable TLS certificate check                                                                                 |
 | xtm:openbas_disable_display     | XTM__OPENBAS_DISABLE_DISPLAY     | false         | Disable OpenBAS posture in the UI                                                                            |


### PR DESCRIPTION
According to this commit
https://github.com/fbicyber/opencti__opencti/commit/39c382cbf0d2232b8abbd5d5c7d3c8edeefec3f4

The variable to override the openbas API is this one: XTM__OPENBAS_API_OVERRIDE_URL