### PR TITLE
[docs] update Opensearch plugin link for fileIndexing(#275)

### DIFF
--- a/docs/administration/file-indexing.md
+++ b/docs/administration/file-indexing.md
@@ -10,7 +10,7 @@ In order to [search in files](../usage/search.md#full-text-search-in-files-conte
 
 * Elasticsearch >= 8.4
 * Elasticsearch < 8.4 with [ingest-attachment plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/8.3/ingest-attachment.html)
-* OpenSearch with [ingest-attachment plugin](https://opensearch.org/docs/2.9/install-and-configure/plugins/)
+* OpenSearch with [ingest-attachment plugin](https://opensearch.org/docs/latest/install-and-configure/additional-plugins/ingest-attachment-plugin/)
 
 ## File indexing configuration
 


### PR DESCRIPTION
closes: https://github.com/OpenCTI-Platform/docs/issues/275
Actual doc link to the opensearch doc version wich is not maintened any more:
![image](https://github.com/user-attachments/assets/1c5789c9-dc11-4e5f-8faf-2510999f7fa2)
 