### PR TITLE
[deploy] clarify that token-based connections are now stateless

### DIFF
--- a/docs/administration/enterprise.md
+++ b/docs/administration/enterprise.md
@@ -50,7 +50,7 @@ Automatic extraction of entities and relationships from raw text (PDF, etc.).
 
 ### Natural Language Query
 
-Automatic extraction of filters to display a filtered entities list from a question or assertion (please read [Natural Language Query](../usage/ask-ai.md#nlq-section)).
+Automatic extraction of filters to display a filtered entities list from a question or assertion (please read [Natural Language Query](../usage/refine-content.md#nlq-section)).
 
 ### Fintel templates
 

--- a/docs/deployment/connectors.md
+++ b/docs/deployment/connectors.md
@@ -226,6 +226,13 @@ Then just get the token of the user displayed in the interface.
 
 ![User token](assets/user-token.png)
 
+!!! info "Stateless connections"
+
+    The user associated with the connector will be used to authenticate to the platform GraphQL API using the user's token.
+    Please note that, since OpenCTI 6.6.0, token-based connections will never create persistent user sessions in the platform.
+    This is no longer an option "stateless mode" that can be set manually from the user's configuration page.
+
+
 ## Docker activation
 
 You can either directly run the Docker image of connectors or add them to your current `docker-compose.yml` file.


### PR DESCRIPTION
Following https://github.com/OpenCTI-Platform/opencti/issues/8877

The advanced option "stateless" in user's overview has also disappeared, but I did not find a mention of it.