### PR TITLE
List missing RabbitMQ config options

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -186,9 +186,11 @@ Here are the configuration keys, for both containers (environment variables) and
 |:--------------------------------------------|:----------------------------------|:--------------|:--------------------------------------------|
 | rabbitmq:hostname                           | RABBITMQ__HOSTNAME                | localhost     | Hostname of the RabbitMQ server             |
 | rabbitmq:port                               | RABBITMQ__PORT                    | 5672          | Port of the RabbitMQ server                 |
+| rabbitmq:host_management                    | RABBITMQ__HOST_MANAGEMENT         |               | Hostname of the RabbitMQ Management Plugin  |
 | rabbitmq:port_management                    | RABBITMQ__PORT_MANAGEMENT         | 15672         | Port of the RabbitMQ Management Plugin      |
 | rabbitmq:username                           | RABBITMQ__USERNAME                | guest         | RabbitMQ user                               |
 | rabbitmq:password                           | RABBITMQ__PASSWORD                | guest         | RabbitMQ password                           |
+| rabbitmq:vhost                              | RABBITMQ__VHOST                   | "/"           | RabbitMQ virtual host                       |
 | rabbitmq:queue_type                         | RABBITMQ__QUEUE_TYPE              | "classic"     | RabbitMQ Queue Type ("classic" or "quorum") |
 | -                                           | -                                 | -             | -                                           |
 | rabbitmq:use_ssl                            | RABBITMQ__USE_SSL                 | `false`       | Use TLS connection                          |

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -186,7 +186,7 @@ Here are the configuration keys, for both containers (environment variables) and
 |:--------------------------------------------|:----------------------------------|:--------------|:--------------------------------------------|
 | rabbitmq:hostname                           | RABBITMQ__HOSTNAME                | localhost     | Hostname of the RabbitMQ server             |
 | rabbitmq:port                               | RABBITMQ__PORT                    | 5672          | Port of the RabbitMQ server                 |
-| rabbitmq:host_management                    | RABBITMQ__HOST_MANAGEMENT         |               | Hostname of the RabbitMQ Management Plugin  |
+| rabbitmq:hostname_management                | RABBITMQ__HOSTNAME_MANAGEMENT     |               | Hostname of the RabbitMQ Management Plugin  |
 | rabbitmq:port_management                    | RABBITMQ__PORT_MANAGEMENT         | 15672         | Port of the RabbitMQ Management Plugin      |
 | rabbitmq:username                           | RABBITMQ__USERNAME                | guest         | RabbitMQ user                               |
 | rabbitmq:password                           | RABBITMQ__PASSWORD                | guest         | RabbitMQ password                           |


### PR DESCRIPTION
I found two config options for RabbitMQ [here](https://github.com/OpenCTI-Platform/opencti/blob/ae6c330775e12ae5d908240dbe47305087b1205d/opencti-platform/opencti-graphql/src/database/rabbitmq.js#L18) that aren't listed on https://docs.opencti.io/latest/deployment/configuration/#rabbitmq